### PR TITLE
changed updated_at to pushed_at

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -86,7 +86,7 @@ function showData(data) {
                 <td><a href="${fork.html_url}">${fork.full_name}</a></td>
                 <td>${fork.stargazers_count}</td>
                 <td>${fork.forks_count}</td>
-                <td>${timeSince(fork.updated_at)} ago</td>
+                <td>${timeSince(fork.pushed_at)} ago</td>
             </tr>
         `;
         html.push(item);

--- a/js/main.js
+++ b/js/main.js
@@ -75,7 +75,7 @@ function showData(data) {
                 <th><i class="fa fa-github" aria-hidden="true"></i> Repository</th>
                 <th><i class="fa fa-star" aria-hidden="true"></i> Stargazers</th>
                 <th><i class="fa fa-code-fork" aria-hidden="true"></i> Forks</th>
-                <th><i class="fa fa-clock-o" aria-hidden="true"></i> Last Update</th>
+                <th><i class="fa fa-clock-o" aria-hidden="true"></i> Last Push</th>
             </tr>
         </thead>
     `;


### PR DESCRIPTION
This seems to be much more useful. Updated_at doesn't mean any meaningful activity.  
I found that looking at  `elastic/sense` forks, where `bleskes/sense` is the first one. `Updated_at` is 19 days ago, however last commit or any activity was 2 years ago.