### PR TITLE
repo names have the domain preprended, added replace to remove it b4 …

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -100,6 +100,7 @@ function fetchAndShow(repo) {
   repo = repo.replace('https://github.com/', '');
   repo = repo.replace('http://github.com/', '');
   repo = repo.replace('.git', '');
+  repo = repo.replace(/^github.com\//, '');
 
   fetch(
     `https://api.github.com/repos/${repo}/forks?sort=stargazers&per_page=100`


### PR DESCRIPTION
repo names have the domain preprended, added replace to remove it b4 the fetch:

repo contains 'github.com/<username>/<repo>...' which causes a 404 in the api call

added a replace() all to remove it

