### PR TITLE
Only replace .git if it occurs at the end.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -99,7 +99,7 @@ function initDT() {
 function fetchAndShow(repo) {
   repo = repo.replace('https://github.com/', '');
   repo = repo.replace('http://github.com/', '');
-  repo = repo.replace('.git', '');
+  repo = repo.replace(/.git$/, '');
 
   fetch(
     `https://api.github.com/repos/${repo}/forks?sort=stargazers&per_page=100`


### PR DESCRIPTION
Previously, foo/bar.github.io would be turned into foo/barhub.io.

Fixes #36