### PR TITLE
Update main.js

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -74,8 +74,8 @@ function initDT() {
     ['Last Push', 'pushed_at'],
   ];
 
-  // Sort by stars:
-  const sortColName = 'Stars';
+  // Sort by "Last Push":
+  const sortColName = 'Last Push';
   const sortColumnIdx = window.columnNamesMap
     .map(pair => pair[0])
     .indexOf(sortColName);


### PR DESCRIPTION
I think the main point of the project (as title says) is to show the Active Forks.
However, when we enter the site and type repo-url ,   it doesn't give the results sorted by the "latest push"  (which is the sign of "activeness"). So there should be `Last Push` instead of  `Stars`. If user wants it to be sorted by *stars*, then s/he should do it explicitly, as the project is not title "most popular forks", instead the project's first action should be as expected by its name "active" forks.

Would be nice if you defaulted that and to meet expectations of users. 

Or, it would be nice if there was "save" (in localstorage or whatever) the preferred action for visitor, so, once I choose by "Last push", then every visit on the site and using the tool, should sort by preferred column.