### PR TITLE
Replace Moment.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     <script type="text/javascript" src="https://cdn.datatables.net/1.10.24/js/dataTables.bootstrap4.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.0.1/js/dataTables.searchBuilder.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.0.1/js/searchBuilder.bootstrap4.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.0/moment.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/darkmode-js@1.5.7/lib/darkmode-js.min.js"></script>
 
     <style>

--- a/js/main.js
+++ b/js/main.js
@@ -59,6 +59,27 @@ function updateDT(data) {
     .draw();
 }
 
+function howLongAgo(date) {
+  const relTime = new Intl.RelativeTimeFormat('en', { style: 'long' });
+  const startDateMilliseconds = Date.parse(date);
+  const endDateMilliseconds = Date.parse(new Date());
+
+  const elapsedSeconds = (endDateMilliseconds - startDateMilliseconds) / 1000;
+  const elapsedHours = elapsedSeconds / 60 / 60;
+  const elapsedDays = elapsedHours / 24;
+  const elapsedMonths = elapsedDays / 30;
+  const elapsedYears = elapsedDays / 365;
+
+  if(elapsedHours < 24)
+    return `${relTime.format(-Math.floor(elapsedHours), 'hour')}`;
+  else if(elapsedDays < 31)
+    return `${relTime.format(-Math.floor(elapsedDays, 'day'))}`;
+  else if(elapsedMonths < 12)
+    return `${relTime.format(-Math.floor(elapsedMonths, 'month'))}`;
+  else
+    return `${relTime.format(-Math.floor(elapsedYears, 'year'))}`;
+}
+
 function initDT() {
   // Create ordered Object with column name and mapped display name
   window.columnNamesMap = [
@@ -90,7 +111,7 @@ function initDT() {
           colNM[1] === 'pushed_at'
             ? (data, type, _row) => {
                 if (type === 'display') {
-                  return moment(data).fromNow();
+                  return howLongAgo(data);
                 }
                 return data;
               }

--- a/js/main.js
+++ b/js/main.js
@@ -59,6 +59,7 @@ function updateDT(data) {
     .draw();
 }
 
+// Will replace with JavaScript Temporal once supported in major browsers
 function howLongAgo(date) {
   const relTime = new Intl.RelativeTimeFormat('en', { style: 'long' });
   const startDateMilliseconds = Date.parse(date);

--- a/js/main.js
+++ b/js/main.js
@@ -69,7 +69,7 @@ function howLongAgo(date) {
   const elapsedHours = elapsedSeconds / 60 / 60;
   const elapsedDays = elapsedHours / 24;
   const elapsedMonths = elapsedDays / 30;
-  const elapsedYears = elapsedDays / 365;
+  const elapsedYears = elapsedDays / 365.25;
 
   if(elapsedHours < 24)
     return `${relTime.format(-Math.floor(elapsedHours), 'hour')}`;

--- a/js/main.js
+++ b/js/main.js
@@ -102,7 +102,6 @@ function initDT() {
     .indexOf(sortColName);
 
   // Use first index for readable column name
-  // we use moment's fromNow() if we are rendering for `pushed_at`; better solution welcome
   window.forkTable = $('#forkTable').DataTable({
     columns: window.columnNamesMap.map(colNM => {
       return {


### PR DESCRIPTION
Since `Moment.js` is now a legacy project, the developers behind it [recommend moving to other solutions](https://momentjs.com/docs/) if using only its basic features. This pull request replaces the 58 KB request to `Moment.js` with a <1 KB function using `Intl.RelativeTimeFormat`. The data in the "Last Push" column retains the same appearance of "5 hours ago", "12 days ago", "2 months ago", "6 years ago", and so on.

If the last push was less than 31 days ago, the time ago will be exact to the second (except when dealing with leap seconds or maybe Daylight Savings Time, depending on how the browsers' implementations work). Otherwise, it will be approximate because months are represented in 30-day increments (instead of taking into account 30, 31, or 28/29 days for various calendar months), and years are represented as 365.25 days (which doesn't take into account the difference between sidereal and solar years). Once [JavaScript Temporal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) is supported in all major browsers, we can easily migrate to it and get to-the-second precision with all time units.