### PR TITLE
Fix relative time formatting in howLongAgo function

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -61,7 +61,7 @@ function updateDT(data) {
 
 // Will replace with JavaScript Temporal once supported in major browsers
 function howLongAgo(date) {
-  const relTime = new Intl.RelativeTimeFormat('en', { style: 'long' });
+  const relTime = new Intl.RelativeTimeFormat(undefined, { style: 'long' });
   const startDateMilliseconds = Date.parse(date);
   const endDateMilliseconds = Date.parse(new Date());
 
@@ -72,13 +72,12 @@ function howLongAgo(date) {
   const elapsedYears = elapsedDays / 365.25;
 
   if(elapsedHours < 24)
-    return `${relTime.format(-Math.floor(elapsedHours), 'hour')}`;
-  else if(elapsedDays < 31)
-    return `${relTime.format(-Math.floor(elapsedDays, 'day'))}`;
-  else if(elapsedMonths < 12)
-    return `${relTime.format(-Math.floor(elapsedMonths, 'month'))}`;
-  else
-    return `${relTime.format(-Math.floor(elapsedYears, 'year'))}`;
+    return relTime.format(-Math.floor(elapsedHours), 'hour');
+  if(elapsedDays < 31)
+    return relTime.format(-Math.floor(elapsedDays), 'day');
+  if(elapsedMonths < 12)
+    return relTime.format(-Math.floor(elapsedMonths), 'month');
+  return relTime.format(-Math.floor(elapsedYears), 'year');
 }
 
 function initDT() {


### PR DESCRIPTION
**Pull Request: Fix relative time formatting in `howLongAgo` function**

A bug was preventing active forks from being correctly searched due to an issue in the `howLongAgo` function, which is used for displaying relative times. The root cause of the error includes:

- **Incorrect usage of `Math.floor()`:**  
  The function was mistakenly calling `Math.floor(elapsedDays, 'day')` instead of `Math.floor(elapsedDays)`, causing the extra parameter to be ignored.
  
- **Missing unit parameter in format calls:**  
  The calls to `Intl.RelativeTimeFormat.format()` were missing proper unit parameters, leading to faulty relative time outputs.
  
- **Hardcoded locale conflict:**  
  A hardcoded English ('en') locale conflicted with German number formatting. This change now relies on the browser-default locale.

**Changes Made:**

1. **Locale Adjustment:**  
   Removed the hardcoded `'en'` locale to automatically use the browser's default language (e.g., German), which resolves conflicts with local formatting.

2. **Parameter Correction:**  
   Fixed the placement of unit parameters in all calls to `Intl.RelativeTimeFormat.format()`, ensuring correct relative time formatting.

3. **Template Literal Cleanup:**  
   Removed unnecessary template literals since `format()` already returns a string.

4. **Math.floor() Fix:**  
   Corrected the `Math.floor()` parameter count to pass only the required value.

These modifications resolve the error affecting active fork searches and ensure that relative time is accurately formatted across different locales.
