### PR TITLE
Error handling for undefined "pushed at" times

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -61,7 +61,9 @@ function updateDT(data) {
 
 // Will replace with JavaScript Temporal once supported in major browsers
 function howLongAgo(date) {
-  const relTime = new Intl.RelativeTimeFormat(undefined, { style: 'long' });
+  const relTime = new Intl.RelativeTimeFormat(navigator.language, { style: 'long' });
+  if(!date) return 'Unknown';
+
   const startDateMilliseconds = Date.parse(date);
   const endDateMilliseconds = Date.parse(new Date());
 


### PR DESCRIPTION
As pointed out by @CrazyCSIW6, if the "pushed_at" time for a repository is undefined, the page will crash. This pull request means "Unknown" will be displayed if the "pushed_at" time is undefined (as displaying "0 seconds ago" may not accurately represent how long ago the repository was pushed).

Also, as pointed out by [Jono Job on StackOverflow](https://stackoverflow.com/a/79146962), passing undefined into `Intl.DateTimeFormat` actually sets the locale to the _runtime_ default locale rather than the user-set locale. Instead, passing `navigator.language` will set the locale to the user-set locale.