### PR TITLE
Upgrade to Bootstrap 5 and switch to native dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>Active GitHub Forks</title>
 
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.2.2/css/dataTables.bootstrap.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.2.2/css/dataTables.bootstrap5.min.css"/>
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/searchbuilder/1.8.2/css/searchBuilder.bootstrap5.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/searchbuilder/1.8.2/css/searchBuilder.bootstrap5.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="style.css">
 
     <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.slim.min.js" integrity="sha384-5AkRS45j4ukf+JbWAfHL8P4onPA9p0KwwP7pUdjSQA3ss9edbJUJc/XcYAiheSSz" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
@@ -17,12 +18,6 @@
     <script type="text/javascript" src="https://cdn.datatables.net/2.2.2/js/dataTables.bootstrap5.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.8.2/js/dataTables.searchBuilder.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.8.2/js/searchBuilder.bootstrap5.min.js"></script>
-
-    <style>
-        th:nth-child(2) { width: 30%; }
-        th, tr, td { border: none; }
-        #dark-mode-toggle { border: none; border-radius: 100%; background-color: var(--bs-emphasis-color); width: 3rem; height: 3rem; position: fixed; right: 2rem; bottom: 2rem; z-index: 5; }
-    </style>
 </head>
 
 <body class='pt-4 pb-2 bg-body'>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         html { background: var(--bs-body-bg); }
         body { min-height: 100vh; }
         .darkmode-layer, .darkmode-toggle { z-index: 500; }
+        h3 > a { color: var(--bs-emphasis-color); }
         th:nth-child(2) { width: 30%; }
         tbody tr:nth-child(odd) { background-color: var(--bs-tertiary-bg); }
         table.dataTable th.dt-type-numeric, table.dataTable td.dt-type-numeric { text-align: start; }
@@ -36,7 +37,7 @@
                 <div class="card">
                     <div class="card-header text-center">
                         <h3>
-                            <a href="https://github.com/techgaun/active-forks" class="text-dark">
+                            <a href="https://github.com/techgaun/active-forks">
                                 <i class="fa fa-github-alt pull-left" aria-hidden="true"></i>
                             </a>
                             Active GitHub Forks

--- a/index.html
+++ b/index.html
@@ -17,27 +17,21 @@
     <script type="text/javascript" src="https://cdn.datatables.net/2.2.2/js/dataTables.bootstrap5.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.8.2/js/dataTables.searchBuilder.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.8.2/js/searchBuilder.bootstrap5.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/darkmode-js@1.5.7/lib/darkmode-js.min.js"></script>
 
     <style>
-        html { background: var(--bs-body-bg); }
-        body { min-height: 100vh; }
-        .darkmode-layer, .darkmode-toggle { z-index: 500; }
-        h3 > a { color: var(--bs-emphasis-color); }
         th:nth-child(2) { width: 30%; }
-        tbody tr:nth-child(odd) { background-color: var(--bs-tertiary-bg); }
-        table.dataTable th.dt-type-numeric, table.dataTable td.dt-type-numeric { text-align: start; }
+        #dark-mode-toggle { border: none; border-radius: 100%; background-color: var(--bs-emphasis-color); width: 3rem; height: 3rem; position: fixed; right: 2rem; bottom: 2rem; z-index: 5; }
     </style>
 </head>
 
-<body class='pt-4 pb-2'>
+<body class='pt-4 pb-2 bg-body'>
     <div class="container">
         <div class="row">
             <div class="col-sm-12 col-lg-12">
                 <div class="card">
                     <div class="card-header text-center">
                         <h3>
-                            <a href="https://github.com/techgaun/active-forks">
+                            <a href="https://github.com/techgaun/active-forks" class="text-body-emphasis">
                                 <i class="fa fa-github-alt pull-left" aria-hidden="true"></i>
                             </a>
                             Active GitHub Forks
@@ -59,12 +53,16 @@
                         </div>
 
                         <div id="data-body"></div>
-                        <table id="forkTable" class="display table-sm table-striped" width="100%"></table>
+                        <table id="forkTable" class="display table table-sm table-striped text-start" width="100%"></table>
                     </div>
                     <div id="footer" class="card-footer text-muted"></div>
                 </div>
             </div>
         </div>
     </div>
+    <button id="dark-mode-toggle" aria-pressed="false">
+        <span class="visually-hidden">Toggle Dark Mode</span>
+        <span aria-hidden="true">🌓</span>
+    </button>
     <script type="text/javascript" src="js/main.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/darkmode-js@1.5.7/lib/darkmode-js.min.js"></script>
 
     <style>
+        html { background: var(--bs-body-bg); }
+        body { min-height: 100vh; }
         .darkmode-layer, .darkmode-toggle { z-index: 500; }
         th:nth-child(2) { width: 30%; }
         tbody tr:nth-child(odd) { background-color: var(--bs-tertiary-bg); }
@@ -27,7 +29,7 @@
     </style>
 </head>
 
-<body class='mt-4 mb-2'>
+<body class='pt-4 pb-2'>
     <div class="container">
         <div class="row">
             <div class="col-sm-12 col-lg-12">

--- a/index.html
+++ b/index.html
@@ -5,22 +5,25 @@
     <title>Active GitHub Forks</title>
 
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.24/css/dataTables.bootstrap4.min.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/searchbuilder/1.0.1/css/searchBuilder.bootstrap4.min.css"/>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.2.2/css/dataTables.bootstrap.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/searchbuilder/1.8.2/css/searchBuilder.bootstrap5.min.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/1.10.24/js/dataTables.bootstrap4.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.0.1/js/dataTables.searchBuilder.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.0.1/js/searchBuilder.bootstrap4.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.slim.min.js" integrity="sha384-5AkRS45j4ukf+JbWAfHL8P4onPA9p0KwwP7pUdjSQA3ss9edbJUJc/XcYAiheSSz" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js" integrity="sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/2.2.2/js/dataTables.min.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/2.2.2/js/dataTables.bootstrap5.min.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.8.2/js/dataTables.searchBuilder.min.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.8.2/js/searchBuilder.bootstrap5.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/darkmode-js@1.5.7/lib/darkmode-js.min.js"></script>
 
     <style>
         .darkmode-layer, .darkmode-toggle { z-index: 500; }
+        th:nth-child(2) { width: 30%; }
+        tbody tr:nth-child(odd) { background-color: var(--bs-tertiary-bg); }
+        table.dataTable th.dt-type-numeric, table.dataTable td.dt-type-numeric { text-align: start; }
     </style>
 </head>
 
@@ -39,7 +42,7 @@
                     </div>
 
                     <div class="card-body">
-                        <div class="form-group">
+                        <div class="mb-3">
                           <form id="form" role="form">
                               <div class="input-group">
                                   <input id="q" name="q" class="form-control" type="text" placeholder="techgaun/github-dorks">

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
 
     <style>
         th:nth-child(2) { width: 30%; }
+        th, tr, td { border: none; }
         #dark-mode-toggle { border: none; border-radius: 100%; background-color: var(--bs-emphasis-color); width: 3rem; height: 3rem; position: fixed; right: 2rem; bottom: 2rem; z-index: 5; }
     </style>
 </head>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
                         <div class="mb-3">
                           <form id="form" role="form">
                               <div class="input-group">
-                                  <input id="q" name="q" class="form-control" type="text" placeholder="techgaun/github-dorks">
+                                  <input id="q" name="q" class="form-control" type="text" placeholder="techgaun/github-dorks" spellcheck="false">
                                   <span class="input-group-btn">
                                       <button id="find" onClick="fetchData()" type="button" class="btn btn-primary">
                                           <i id="spinner" class="fa fa-spinner fa-pulse fa-fw" hidden></i> Find

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,7 @@
 window.addEventListener('load', () => {
   initDT(); // Initialize the DatatTable and window.columnNames variables
   document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
+  if(localStorage.getItem('darkmode') === '1') document.body.setAttribute('data-bs-theme', 'dark');
 
   const repo = getRepoFromUrl();
 
@@ -182,7 +183,8 @@ function getRepoFromUrl() {
 
 function toggleDarkMode(event) {
   const button = event.target;
-  if(button.ariaPressed === 'false') button.ariaPressed = 'true';
-  else button.ariaPressed = 'false';
+  if(button.ariaPressed === 'true') button.ariaPressed = 'false';
+  else button.ariaPressed = 'true';
   document.body.setAttribute('data-bs-theme', button.ariaPressed === 'true' ? 'dark' : 'light');
+  localStorage.setItem('darkmode', document.body.getAttribute('data-bs-theme') === 'dark' ? 1 : 0);
 }

--- a/js/main.js
+++ b/js/main.js
@@ -47,7 +47,7 @@ function updateDT(data) {
   const forks = [];
   for (let fork of data) {
     fork.repoLink = `<a href="https://github.com/${fork.full_name}">Link</a>`;
-    fork.ownerName = `<img src="${fork.owner.avatar_url || 'https://avatars.githubusercontent.com/u/0?v=4'}&s=48" width="24" height="24" class="mr-2 rounded-circle" />${fork.owner ? fork.owner.login : '<strike><em>Unknown</em></strike>'}`;
+    fork.ownerName = `<img src="${fork.owner.avatar_url || 'https://avatars.githubusercontent.com/u/0?v=4'}&s=48" width="24" height="24" class="me-2 rounded-circle" />${fork.owner ? fork.owner.login : '<strike><em>Unknown</em></strike>'}`;
     forks.push(fork);
   }
   const dataSet = forks.map(fork =>

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 window.addEventListener('load', () => {
   initDT(); // Initialize the DatatTable and window.columnNames variables
-  addDarkmodeWidget();
+  document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
 
   const repo = getRepoFromUrl();
 
@@ -14,10 +14,6 @@ document.getElementById('form').addEventListener('submit', e => {
   e.preventDefault();
   fetchData();
 });
-
-function addDarkmodeWidget() {
-  new Darkmode( { label: '🌓' } ).showWidget();
-}
 
 function fetchData() {
   const repo = document.getElementById('q').value.replaceAll(' ','');
@@ -182,4 +178,11 @@ function getRepoFromUrl() {
   const urlRepo = location.hash && location.hash.slice(1);
 
   return urlRepo && decodeURIComponent(urlRepo);
+}
+
+function toggleDarkMode(event) {
+  const button = event.target;
+  if(button.ariaPressed === 'false') button.ariaPressed = 'true';
+  else button.ariaPressed = 'false';
+  document.body.setAttribute('data-bs-theme', button.ariaPressed === 'true' ? 'dark' : 'light');
 }

--- a/style.css
+++ b/style.css
@@ -1,5 +1,8 @@
 th:nth-child(2) {
-	width: 30%;
+	width: 15%;
+}
+th:nth-child(3) {
+	width: 25%;
 }
 th, tr, td {
 	border: none;

--- a/style.css
+++ b/style.css
@@ -1,0 +1,39 @@
+th:nth-child(2) {
+	width: 30%;
+}
+th, tr, td {
+	border: none;
+}
+#dark-mode-toggle {
+	border: none;
+	border-radius: 100%;
+	background-color: var(--bs-emphasis-color);
+	width: 3rem;
+	height: 3rem;
+	position: fixed;
+	right: 2rem;
+	bottom: 2rem;
+	z-index: 5;
+}
+[data-bs-theme=dark] {
+	--bs-border-color: #647078;
+}
+table.dataTable thead > tr > th.dt-orderable-asc span.dt-column-order:before, table.dataTable thead > tr > th.dt-orderable-asc span.dt-column-order:after, table.dataTable thead > tr > th.dt-orderable-desc span.dt-column-order:before, table.dataTable thead > tr > th.dt-orderable-desc span.dt-column-order:after, table.dataTable thead > tr > th.dt-ordering-asc span.dt-column-order:before, table.dataTable thead > tr > th.dt-ordering-asc span.dt-column-order:after, table.dataTable thead > tr > th.dt-ordering-desc span.dt-column-order:before, table.dataTable thead > tr > th.dt-ordering-desc span.dt-column-order:after,
+table.dataTable thead > tr > td.dt-orderable-asc span.dt-column-order:before,
+table.dataTable thead > tr > td.dt-orderable-asc span.dt-column-order:after,
+table.dataTable thead > tr > td.dt-orderable-desc span.dt-column-order:before,
+table.dataTable thead > tr > td.dt-orderable-desc span.dt-column-order:after,
+table.dataTable thead > tr > td.dt-ordering-asc span.dt-column-order:before,
+table.dataTable thead > tr > td.dt-ordering-asc span.dt-column-order:after,
+table.dataTable thead > tr > td.dt-ordering-desc span.dt-column-order:before,
+table.dataTable thead > tr > td.dt-ordering-desc span.dt-column-order:after {
+	opacity: 0.4;
+}
+table.dataTable thead > tr > th.dt-ordering-asc span.dt-column-order:before, table.dataTable thead > tr > th.dt-ordering-desc span.dt-column-order:after,
+table.dataTable thead > tr > td.dt-ordering-asc span.dt-column-order:before,
+table.dataTable thead > tr > td.dt-ordering-desc span.dt-column-order:after {
+	opacity: 1;
+}
+table.dataTable th.dt-type-numeric {
+	text-align: left;
+}

--- a/style.css
+++ b/style.css
@@ -34,6 +34,6 @@ table.dataTable thead > tr > td.dt-ordering-asc span.dt-column-order:before,
 table.dataTable thead > tr > td.dt-ordering-desc span.dt-column-order:after {
 	opacity: 1;
 }
-table.dataTable th.dt-type-numeric {
-	text-align: left;
+table.dataTable th.dt-type-numeric, table.dataTable td.dt-type-numeric {
+	text-align: start;
 }


### PR DESCRIPTION
DarkMode.js achieves dark mode by inverting all the colors on the page, leading to strange-looking avatars in the forks list. In addition, DarkMode.js uses `aria-label` to add an accessible name to the button, [which cannot be automatically translated](https://adrianroselli.com/2019/11/aria-label-does-not-translate.html#Update06) (at least in browsers older than December 2024, according to my testing). Bootstrap 5 introduces native dark mode CSS that can be toggled by just adding `data-bs-theme="dark"` to the HTML, hence this pull request.

A few of the classes change from Bootstrap 4 to 5, which is why some of the classes are altered (like from `form-group` to `mb-3`). The rest of the class changes are either to accommodate native dark mode (for example, `text-body-emphasis` is black in light mode and white in dark mode), or helping to accommodate for right-to-left text direction for those using auto-translation services when reading the page (like from `mr-2` to `me-2`). To solve the `aria-label` issue, the button uses Bootstrap's `visually-hidden` class for the accessible name.

Before (light mode):
![Looks alright.](https://github.com/user-attachments/assets/896ba7bc-a201-421c-87e5-35283beb8765)

After (light mode):
![Links are now underlined and the Add Condition button has better contrast.](https://github.com/user-attachments/assets/a729e873-3a83-4869-a805-d37b71184abd)

Before (dark mode):
![Avatars are color-inverted and the contrast of some control borders are too low.](https://github.com/user-attachments/assets/5ba88824-02ee-45ed-aa06-315a44b0748c)

After (dark mode):
![The above issues are fixed, with the help of some custom CSS.](https://github.com/user-attachments/assets/204424a4-4a40-4a52-85bf-604e475acdc3)

Since DataTables for Bootstrap 5 has a really low `opacity` for ascending/descending controls (only `0.125`!), and [their CSS rules use very high specificity](https://github.com/DataTables/DataTablesSrc/blob/decdda1e863a714d0a90870aa0623690ec03cd7d/css/ordering.scss), I had to include some long CSS rules to get the contrast to an acceptable level. Therefore, I decided to move the styles into a separate CSS file to prevent cluttering the HTML file.

P.S. While I was more thorough in my testing, if this does introduce any bugs and someone submits a pull request to fix such bug(s), we need to ensure that they consent to having the code re-licensed before merging the pull request.