### PR TITLE
Make the forks table responsive and increase focus indicator contrasts

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -54,6 +54,7 @@ function updateDT(data) {
     .clear()
     .rows.add(dataSet)
     .draw();
+  makeTableKeyboardScrollable();
 }
 
 // Will replace with JavaScript Temporal once supported in major browsers
@@ -125,6 +126,7 @@ function initDT() {
   let table = window.forkTable;
   new $.fn.dataTable.SearchBuilder(table, {});
   table.searchBuilder.container().prependTo(table.table().container());
+  makeTableKeyboardScrollable();
 }
 
 function fetchAndShow(repo) {
@@ -187,4 +189,12 @@ function toggleDarkMode(event) {
   else button.ariaPressed = 'true';
   document.body.setAttribute('data-bs-theme', button.ariaPressed === 'true' ? 'dark' : 'light');
   localStorage.setItem('darkmode', document.body.getAttribute('data-bs-theme') === 'dark' ? 1 : 0);
+}
+
+function makeTableKeyboardScrollable() {
+  const tableContainer = document.querySelector('.dt-layout-full');
+  tableContainer.setAttribute('aria-labelledby', 'table-container-label');
+  tableContainer.setAttribute('role', 'region');
+  tableContainer.setAttribute('tabindex', '0');
+  tableContainer.style.overflowX = 'auto';
 }

--- a/js/main.js
+++ b/js/main.js
@@ -196,5 +196,5 @@ function makeTableKeyboardScrollable() {
   tableContainer.setAttribute('aria-labelledby', 'table-container-label');
   tableContainer.setAttribute('role', 'region');
   tableContainer.setAttribute('tabindex', '0');
-  tableContainer.style.overflowX = 'auto';
+  tableContainer.classList.add('table-responsive');
 }

--- a/style.css
+++ b/style.css
@@ -40,3 +40,7 @@ table.dataTable thead > tr > td.dt-ordering-desc span.dt-column-order:after {
 table.dataTable th.dt-type-numeric, table.dataTable td.dt-type-numeric {
 	text-align: start;
 }
+.form-control:focus, .btn-primary:focus, .btn-secondary:focus, .form-select:focus, .dt-column-order:focus, .dt-layout-full:focus, table a:focus, .page-link:focus {
+	outline: 0.125rem solid white;
+	box-shadow: 0 0 0 0.25rem blue;
+}

--- a/style.css
+++ b/style.css
@@ -44,3 +44,10 @@ table.dataTable th.dt-type-numeric, table.dataTable td.dt-type-numeric {
 	outline: 0.125rem solid white;
 	box-shadow: 0 0 0 0.25rem blue;
 }
+button:focus:not(:focus-visible) {
+	box-shadow: none;
+}
+.form-control:focus-visible, .btn-primary:focus-visible, .btn-secondary:focus-visible, .form-select:focus-visible, .dt-column-order:focus-visible, .dt-layout-full:focus-visible, table a:focus-visible, .page-link:focus-visible {
+	outline: 0.125rem solid white;
+	box-shadow: 0 0 0 0.25rem blue;
+}


### PR DESCRIPTION
The most effective way to make an HTML table responsive (readable regardless of screen size) is to make it horizontally scrollable when the container is smaller than the table via setting `overflow-x: auto` to the container (which is what [Bootstrap 5's "table-responsive" class](https://getbootstrap.com/docs/5.0/content/tables/#responsive-tables) uses).

In order [to allow keyboard-only users to scroll the table](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow), the container element also needs the attributes `tabindex="0"`, `role="region"`, and an accessible name (recommended by both Mozilla Developer Network and [by Adrian Roselli](https://adrianroselli.com/2020/11/under-engineered-responsive-tables.html)). Since the table is added and updated via DataTables, these attributes and styles are set in a function that's called whenever the table is drawn or redrawn.

![Scrolling the table horizontally on a small screen.](https://github.com/user-attachments/assets/c3b970cd-5f7e-40cf-b743-a00affa8c615)

Also, Bootstrap has low-contrast focus indicators by default (which is not good for accessibility), so this pull request also [adds CSS to ensure that focus indicators can be distinguished](https://www.sarasoueidan.com/blog/focus-indicators/) from the interactive elements they contain and the surrounding background, both in light and dark mode. Bootstrap has some high specificity selectors for its focus indicators, so these CSS overrides had to be just as specific (without resorting to the `!important` declaration).

| Mode | Before | After |
| ------------- | ------------- | ------------- |
| Light | ![Low contrast.](https://github.com/user-attachments/assets/0b51851e-3844-44c9-9232-1bca32f70a33)  | ![Sufficient contrast.](https://github.com/user-attachments/assets/f11a3fcd-ca1d-4fd8-8e03-2f35c05b8bb7)  |
| Dark | ![Also low contrast.](https://github.com/user-attachments/assets/692208ba-e0ca-4319-83fd-4ac380b29b46) | ![Good contrast.](https://github.com/user-attachments/assets/13f08a7d-ef9e-437c-a054-376781b72847) |