### PR TITLE
Accessibility: Make landmarks semantic, change h3 to h1, & dark mode button tab order

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,45 +20,45 @@
     <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.8.2/js/searchBuilder.bootstrap5.min.js"></script>
 </head>
 
-<body class='pt-4 pb-2 bg-body'>
-    <div class="container">
+<body class="bg-body">
+    <div class="container pt-4 pb-2">
         <div class="row">
             <div class="col-sm-12 col-lg-12">
                 <div class="card">
-                    <div class="card-header text-center">
-                        <h3>
+                    <header class="card-header text-center">
+                        <h1 class="h3">
                             <a href="https://github.com/techgaun/active-forks" class="text-body-emphasis">
                                 <i class="fa fa-github-alt pull-left" aria-hidden="true"></i>
                             </a>
                             Active GitHub Forks
-                        </h3>
-                    </div>
+                        </h1>
+                    </header>
 
-                    <div class="card-body">
-                        <div class="mb-3">
-                          <form id="form" role="form">
-                              <div class="input-group">
-                                  <input id="q" name="q" class="form-control" type="text" placeholder="techgaun/github-dorks" spellcheck="false">
-                                  <span class="input-group-btn">
-                                      <button id="find" onClick="fetchData()" type="button" class="btn btn-primary">
-                                          <i id="spinner" class="fa fa-spinner fa-pulse fa-fw" hidden></i> Find
-                                      </button>
-                                  </span>
-                              </div>
-                          </form>
-                        </div>
+                    <main class="card-body">
+                        <search class="mb-3">
+                            <form id="form">
+                                <div class="input-group">
+                                    <input id="q" name="q" class="form-control" type="text" placeholder="techgaun/github-dorks" spellcheck="false">
+                                    <span class="input-group-btn">
+                                        <button id="find" onClick="fetchData()" type="button" class="btn btn-primary">
+                                            <i id="spinner" class="fa fa-spinner fa-pulse fa-fw" hidden></i> Find
+                                        </button>
+                                    </span>
+                                </div>
+                            </form>
+                        </search>
 
                         <div id="data-body"></div>
                         <table id="forkTable" class="display table table-sm table-striped text-start" width="100%"></table>
-                    </div>
-                    <div id="footer" class="card-footer text-muted"></div>
+                    </main>
+                    <button id="dark-mode-toggle" aria-pressed="false">
+                        <span class="visually-hidden">Toggle Dark Mode</span>
+                        <span aria-hidden="true">🌓</span>
+                    </button>
+                    <footer id="footer" class="card-footer text-muted"></footer>
                 </div>
             </div>
         </div>
     </div>
-    <button id="dark-mode-toggle" aria-pressed="false">
-        <span class="visually-hidden">Toggle Dark Mode</span>
-        <span aria-hidden="true">🌓</span>
-    </button>
     <script type="text/javascript" src="js/main.js"></script>
 </body>


### PR DESCRIPTION
This pull request includes some accessibility improvements, including:
- [Semantic landmarks](https://www.w3.org/WAI/WCAG22/Techniques/html/H101), e.g. `<header>`, `<search>`, `<main>`, and `<footer>`
- [Use an `<h1>` for the heading instead of an `<h3>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#usage_notes), while styling the heading to look like an `<h3>` (so it still looks the same as before)
- [Move the floating dark mode button between `<main>` and `<footer>`](https://ux.stackexchange.com/questions/148578/tab-order-of-floating-buttons) in the HTML, for a more logical tab order (it's still in the same place visually due to the styling)

The only other changes were changing some of the 2-space tabs to 4-space tabs to match the rest of the file, and moving the `pt-4 pb-2` classes to the `container` div (which will make styling a [skip link](https://getbootstrap.com/docs/5.2/getting-started/accessibility/#visually-hidden-content) easier in the future, if we ever need to add one in the scenario where there's more than 1 link in the header navigation).