### PR TITLE
Update scripts (July 2026)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,19 +6,19 @@
     <title>Active GitHub Forks</title>
 
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/2.3.4/css/dataTables.bootstrap5.min.css" integrity="sha384-zmMNeKbOwzvUmxN8Z/VoYM+i+cwyC14+U9lq4+ZL0Ro7p1GMoh8uq8/HvIBgnh9+" crossorigin="anonymous"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/searchbuilder/1.8.4/css/searchBuilder.bootstrap5.min.css" integrity="sha384-c+17EpI1t/ZAjBoElPoW3nsmP/5974nO3qiFjdyE/JLy0pDYToN1xM+cdrRNTcab" crossorigin="anonymous"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/3.0.1/css/dataTables.bootstrap5.min.css" integrity="sha384-OlHQFPrLwnmeXJfLPQ4jqFbOgPdCIW0hRoNKjPLyIZv7FxVwt3dythZstNHJQRtV" crossorigin="anonymous"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/searchbuilder/2.0.0/css/searchBuilder.bootstrap5.min.css" integrity="sha384-LpDbJGG74MB7AEbd+IHI+dRRD6ZRfxwk/RzXhhQd20+ghqA5FEsVk5ZlrtSR9v6V" crossorigin="anonymous"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.6.0/css/fontawesome.min.css" integrity="sha384-NvKbDTEnL+A8F/AA5Tc5kmMLSJHUO868P+lDtTpJIeQdGYaUIuLr4lVGOEA1OcMy" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.3.1/css/fontawesome.min.css" integrity="sha384-m8DKa0MtZAZlyNgF18TSkQRYTPDY0sEELpwK2YijfYnVFH8kxiaO6hvopM168nue" crossorigin="anonymous">
     <link rel="stylesheet" href="style.css">
 
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.slim.min.js" integrity="sha384-5AkRS45j4ukf+JbWAfHL8P4onPA9p0KwwP7pUdjSQA3ss9edbJUJc/XcYAiheSSz" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-4.0.0.slim.min.js" integrity="sha384-tcspKDb5tWvyRCOWzevlAeQgHeEzYdUHJpcgnIhcP9w4CnfD7DLAcS+k9QzLbRJO" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.min.js" integrity="sha384-G/EV+4j2dNv+tEPo3++6LCgdCROaejBqfUeNjuKAiuXbjrxilcCdDz6ZAVfHWe1Y" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/2.3.4/js/dataTables.min.js" integrity="sha384-n+4gDsCQ+x0o5YCJeYqFY1Yl+qgW41qmMAilIyF/bJwIUeTK00QB845/VijT5pQq" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/2.3.4/js/dataTables.bootstrap5.min.js" integrity="sha384-G85lmdZCo2WkHaZ8U1ZceHekzKcg37sFrs4St2+u/r2UtfvSDQmQrkMsEx4Cgv/W" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.8.4/js/dataTables.searchBuilder.min.js" integrity="sha384-5huBQ/mfeKyn+hIST/C6o5x4W9VntlvCNZY4usMuWOFB0s8ABLE65hOtXqhB+AKJ" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/1.8.4/js/searchBuilder.bootstrap5.min.js" integrity="sha384-9eFZ0WfV3F1WYwtSPlJAQyeKYNmJBE5j1YPuzvkMJM+iQFp2AhwUEBDu/TogLL5c" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/3.0.1/js/dataTables.min.js" integrity="sha384-stLBvQI26SIgZOke0kAZbmVfcxb89mRjkgJ/aRVpYms4krlKaYvhLnDow4tbqS4U" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/3.0.1/js/dataTables.bootstrap5.min.js" integrity="sha384-4d8X9sr6Gnv9AgIQn6bv3lmQxj5fD+9bVAun0/XMmdy7oPRvT0adfiUUiiYpi4Ck" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/2.0.0/js/dataTables.searchBuilder.min.js" integrity="sha384-UL5QAZBHGMYZyViCy3aWS8Eskp8hvRcI6k5LAIrc3irQnl9mG2xogHYbJ3jN5Vhz" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/searchbuilder/2.0.0/js/searchBuilder.bootstrap5.min.js" integrity="sha384-Gx+YjJx+4rFEinJDPfSnMeJyirhCghdZJLDa4L+EdDNjTC46YXGHelsXS62g50Mh" crossorigin="anonymous"></script>
 </head>
 
 <body class="bg-body">

--- a/style.css
+++ b/style.css
@@ -1,3 +1,6 @@
+:root {
+	--dt-order-arrow_opacity: 0.4;
+}
 th:nth-child(2) {
 	width: 15%;
 }
@@ -31,6 +34,10 @@ table.dataTable thead > tr > td.dt-ordering-asc span.dt-column-order:after,
 table.dataTable thead > tr > td.dt-ordering-desc span.dt-column-order:before,
 table.dataTable thead > tr > td.dt-ordering-desc span.dt-column-order:after {
 	opacity: 0.4;
+}
+table.dataTable th.dt-type-numeric div.dt-column-header {
+	flex-direction: row;
+	margin-inline-end: 0.25rem;
 }
 table.dataTable thead > tr > th.dt-ordering-asc span.dt-column-order:before, table.dataTable thead > tr > th.dt-ordering-desc span.dt-column-order:after,
 table.dataTable thead > tr > td.dt-ordering-asc span.dt-column-order:before,


### PR DESCRIPTION
Notes:
- The script updates mandated a few styling changes to keep it looking like it did before (see screenshots below).
- DataTables, as of version 4.0, no longer requires jQuery, which makes PopperJS the only library we use that depends on jQuery now.
- Bootstrap has no updates since my last pull request.
- PopperJS, while having been deprecated for a few years, does not have any known security vulnerabilities (verified via installing it locally via NPM and running `npm audit`). Also, [the latest version of Bootstrap still utilizes PopperJS](https://getbootstrap.com/docs/5.3/components/popovers/).
- FontAwesome is currently non-functional on both [the current production site](https://techgaun.github.io/active-forks/index.html) and when I test it locally. We may need to host the SVGs ourselves (if so, I can open another pull request for that).

Before:
<img width="1469" height="807" alt="The production site as is." src="https://github.com/user-attachments/assets/81d04daf-30d0-4b08-ac44-5b06405dcd30" />
After:
<img width="1469" height="807" alt="The site after updating the scripts." src="https://github.com/user-attachments/assets/5dd373ea-4f79-492c-87bc-c31ec6fce433" />