### PR TITLE
Fix BS5 alert dismissal and null-owner crash; add optional token and fork pagination

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,14 @@
                                         </button>
                                     </span>
                                 </div>
+                                <details class="mt-2">
+                                    <summary class="small">GitHub token (optional) &mdash; raises the API rate limit and fetches more forks</summary>
+                                    <label for="token" class="form-label small mt-2 mb-1">
+                                        Personal access token (no scopes needed; stored only in your browser)
+                                    </label>
+                                    <input id="token" name="token" class="form-control form-control-sm" type="password"
+                                        autocomplete="off" spellcheck="false" placeholder="github_pat_...">
+                                </details>
                             </form>
                         </search>
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,15 @@
 window.addEventListener('load', () => {
   initDT(); // Initialize the DatatTable and window.columnNames variables
   document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
+
+  const tokenInput = document.getElementById('token');
+  tokenInput.value = getToken();
+  tokenInput.addEventListener('change', () => {
+    const token = tokenInput.value.trim();
+    if (token) localStorage.setItem('github-token', token);
+    else localStorage.removeItem('github-token');
+  });
+
   if(localStorage.getItem('darkmode') === '1') document.body.setAttribute('data-bs-theme', 'dark');
 
   const repo = getRepoFromUrl();
@@ -44,7 +53,8 @@ function updateDT(data) {
   const forks = [];
   for (let fork of data) {
     fork.repoLink = `<a href="https://github.com/${fork.full_name}">Link</a>`;
-    fork.ownerName = `<img src="${fork.owner.avatar_url || 'https://avatars.githubusercontent.com/u/0?v=4'}&s=48" width="24" height="24" class="me-2 rounded-circle" />${fork.owner ? fork.owner.login : '<strike><em>Unknown</em></strike>'}`;
+    const avatarUrl = (fork.owner && fork.owner.avatar_url) || 'https://avatars.githubusercontent.com/u/0?v=4';
+    fork.ownerName = `<img src="${avatarUrl}&s=48" width="24" height="24" class="me-2 rounded-circle" />${fork.owner ? fork.owner.login : '<strike><em>Unknown</em></strike>'}`;
     forks.push(fork);
   }
   const dataSet = forks.map(fork =>
@@ -129,6 +139,40 @@ function initDT() {
   makeTableKeyboardScrollable();
 }
 
+function getToken() {
+  const tokenInput = document.getElementById('token');
+  return (tokenInput && tokenInput.value.trim()) || localStorage.getItem('github-token') || '';
+}
+
+// Extract the rel="next" URL from a Link response header, if any
+function parseNextLink(header) {
+  if (!header) return null;
+  const match = header.match(/<([^>]+)>;\s*rel="next"/);
+  return match ? match[1] : null;
+}
+
+async function fetchForkPages(repo, headers, maxPages, signal) {
+  const forks = [];
+  let url = `https://api.github.com/repos/${repo}/forks?sort=stargazers&per_page=100`;
+  let page = 0;
+  let truncated = false;
+
+  while (url) {
+    const response = await fetch(url, { headers, signal });
+    if (!response.ok) throw Error(response.statusText);
+    forks.push(...(await response.json()));
+    page++;
+
+    url = parseNextLink(response.headers.get('link'));
+    if (url && page >= maxPages) {
+      truncated = true;
+      break;
+    }
+  }
+
+  return { forks, truncated };
+}
+
 function fetchAndShow(repo) {
   repo = repo.replace('https://github.com/', '');
   repo = repo.replace('http://github.com/', '');
@@ -138,23 +182,46 @@ function fetchAndShow(repo) {
   repo = repo.replace(/^\/+/, ''); // remove leading slashes
   repo = repo.replace(/\/+$/, ''); // remove trailing slashes
 
-  fetch(
-    `https://api.github.com/repos/${repo}/forks?sort=stargazers&per_page=100`
-  )
-    .then(response => {
-      if (!response.ok) throw Error(response.statusText);
-      return response.json();
-    })
-    .then(data => {
-      updateDT(data);
+  // Cancel any search still in flight so responses can't interleave
+  if (window.activeFetchController) window.activeFetchController.abort();
+  const controller = new AbortController();
+  window.activeFetchController = controller;
+
+  const token = getToken();
+  const headers = { Accept: 'application/vnd.github+json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  // Unauthenticated requests only get 60/hour, so keep page count modest
+  const maxPages = token ? 30 : 4;
+  const spinner = document.getElementById('spinner');
+  spinner.hidden = false;
+
+  fetchForkPages(repo, headers, maxPages, controller.signal)
+    .then(({ forks, truncated }) => {
+      updateDT(forks);
+      if (truncated) {
+        showMsg(
+          `Showing the first ${forks.length} forks. ${
+            token ? '' : 'Add a GitHub token below the search box to fetch more.'
+          }`,
+          'info'
+        );
+      }
     })
     .catch(error => {
+      if (error.name === 'AbortError') return;
       const msg =
         error.toString().indexOf('Forbidden') >= 0
-          ? 'Error: API Rate Limit Exceeded'
+          ? 'Error: API Rate Limit Exceeded. Add a GitHub token below the search box to raise the limit'
           : error;
       showMsg(`${msg}. Additional info in console`, 'danger');
       console.error(error);
+    })
+    .finally(() => {
+      if (window.activeFetchController === controller) {
+        spinner.hidden = true;
+        window.activeFetchController = null;
+      }
     });
 }
 
@@ -169,10 +236,8 @@ function showMsg(msg, type) {
 
   document.getElementById('data-body').innerHTML = `
         <div class="alert ${alert_type} alert-dismissible fade show" role="alert">
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
             ${msg}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
     `;
 }


### PR DESCRIPTION
## Summary

**Bug fixes**
- Alerts couldn't be dismissed since the Bootstrap 5 upgrade: the close button still used BS4 markup (`class="close"` / `data-dismiss`). Now uses `btn-close` + `data-bs-dismiss="alert"`. Fixes #96
- `updateDT()` crashed on forks whose owner account was deleted (`fork.owner.avatar_url` dereferenced before the null-check); such forks now fall back to the anonymous avatar

**Features**
- Optional GitHub personal access token field (collapsed `<details>` under the search box). Stored only in `localStorage`, sent only to api.github.com; raises the rate limit from 60/hr to 5,000/hr and addresses the recurring 403 reports (#55)
- Pagination via `Link: rel="next"` headers to fetch beyond the first 100 forks (#13) — up to 4 pages unauthenticated / 30 pages with a token, with an info alert when results are truncated
- In-flight search is aborted when a new one is submitted (`AbortController`), and the previously unused `#spinner` icon now shows during fetches

## Testing
- `node --check js/main.js`
- `Link` header parser unit-tested; live-tested pagination against `techgaun/active-forks` (100 forks/page, correct `rel=next` URL followed)