### PR TITLE
Add Created, Issues Enabled, and Release columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ rather than version.
 
 ### Changed
 
+- Ahead/behind counts are now fetched in batches of 50 through the GitHub
+  GraphQL API — one rate-limit point per batch instead of one REST request
+  per fork — making sorted full-table lookups near-instant. Forks the batch
+  cannot resolve (renamed or stale listing entries) fall back to the REST
+  compare with its rename rescue
+  ([#104](https://github.com/techgaun/active-forks/pull/104)).
 - The Size column is now rendered in human-readable units (kB/MB/GB/TB);
   sorting and filtering still use the raw value
   ([#101](https://github.com/techgaun/active-forks/pull/101)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ rather than version.
 
 ### Added
 
+- Three new columns ([#105](https://github.com/techgaun/active-forks/pull/105)):
+  Created (fork creation date), Issues Enabled, and Release — the latest
+  release tag, linked to its release page. Fork releases are fetched through
+  the same batched GraphQL request as the ahead/behind counts and therefore
+  need a token; the upstream row's release is fetched via REST and shows
+  without one.
+
 - Non-zero Ahead/Behind counts link to GitHub's compare view, showing the
   fork's unique commits (Ahead) or the upstream commits the fork lacks
   (Behind) ([#103](https://github.com/techgaun/active-forks/pull/103)).

--- a/js/main.js
+++ b/js/main.js
@@ -257,7 +257,8 @@ async function fetchForkPages(repo, headers, maxPages, signal) {
 // currently visible table page — more are fetched on demand as the user
 // pages, sorts or filters. COMPARE_MAX is a per-search safety cap.
 const COMPARE_MAX = 400;
-const COMPARE_CONCURRENCY = 8;
+// Number of forks resolved per GraphQL request (one aliased compare each)
+const GRAPHQL_BATCH_SIZE = 50;
 
 async function startAheadBehind(repo, baseBranch, forks, headers, signal) {
   // Context for rendering ahead/behind cells as links to GitHub's compare view
@@ -269,13 +270,13 @@ async function startAheadBehind(repo, baseBranch, forks, headers, signal) {
   const behindColIdx = window.columnNamesMap.findIndex(colNM => colNM[1] === 'behind_by');
   const queue = [];
   const queued = new Set(); // row indexes already fetched or in flight
-  let activeWorkers = 0;
+  let pumping = false;
   let capWarned = false;
 
+  // Does not redraw — callers draw once per batch of updates
   const applyResult = (rowIdx, ahead, behind) => {
     table.cell(rowIdx, aheadColIdx).data(ahead);
     table.cell(rowIdx, behindColIdx).data(behind);
-    table.draw(false);
   };
 
   const compareOnce = async (login, branch) => {
@@ -289,50 +290,102 @@ async function startAheadBehind(repo, baseBranch, forks, headers, signal) {
     return response.json();
   };
 
-  const worker = async () => {
-    while (queue.length) {
-      if (signal.aborted) return;
-      const { fork, rowIdx } = queue.shift();
+  // REST fallback for a single fork, with the by-id rename rescue. Used for
+  // forks the GraphQL batch could not resolve (renamed/stale listing entries)
+  // and as the wholesale fallback when a GraphQL request itself fails.
+  const restCompareItem = async ({ fork, rowIdx }) => {
+    try {
+      let login = fork.owner.login;
+      let branch = fork.default_branch;
+      let comparison;
       try {
-        let login = fork.owner.login;
-        let branch = fork.default_branch;
-        let comparison;
-        try {
-          comparison = await compareOnce(login, branch);
-        } catch (error) {
-          if (error.status !== 404) throw error;
-          // The forks listing can be stale: the fork may have been renamed or
-          // deleted since. Look it up by immutable id and retry once if renamed.
-          const response = await fetch(`https://api.github.com/repositories/${fork.id}`, { headers, signal });
-          if (!response.ok) throw error;
-          const current = await response.json();
-          if (current.owner.login === login && current.default_branch === branch) {
-            throw error; // same coordinates, e.g. an empty fork — retrying won't help
-          }
-          login = current.owner.login;
-          branch = current.default_branch;
-          comparison = await compareOnce(login, branch);
-        }
-        // Remember the coordinates that worked so cells can link to them
-        fork.compareOwner = login;
-        fork.compareBranch = branch;
-        applyResult(rowIdx, comparison.ahead_by, comparison.behind_by);
+        comparison = await compareOnce(login, branch);
       } catch (error) {
-        if (error.name === 'AbortError') return;
-        // fork deleted, private, or empty — leave cells unknown
+        if (error.status !== 404) throw error;
+        // The forks listing can be stale: the fork may have been renamed or
+        // deleted since. Look it up by immutable id and retry once if renamed.
+        const response = await fetch(`https://api.github.com/repositories/${fork.id}`, { headers, signal });
+        if (!response.ok) throw error;
+        const current = await response.json();
+        if (current.owner.login === login && current.default_branch === branch) {
+          throw error; // same coordinates, e.g. an empty fork — retrying won't help
+        }
+        login = current.owner.login;
+        branch = current.default_branch;
+        comparison = await compareOnce(login, branch);
       }
+      // Remember the coordinates that worked so cells can link to them
+      fork.compareOwner = login;
+      fork.compareBranch = branch;
+      applyResult(rowIdx, comparison.ahead_by, comparison.behind_by);
+      table.draw(false);
+    } catch (error) {
+      if (error.name === 'AbortError') return;
+      // fork deleted, private, or empty — leave cells unknown
     }
   };
 
-  const spawnWorkers = () => {
-    // worker() dequeues its first item synchronously, so queue.length shrinks each spin
-    while (activeWorkers < COMPARE_CONCURRENCY && queue.length) {
-      activeWorkers++;
-      worker().finally(() => {
-        activeWorkers--;
-        if (queue.length) spawnWorkers();
-      });
-    }
+  // Resolve a whole batch with one GraphQL request: an aliased compare per
+  // fork costs a single rate-limit point, vs one REST request per fork.
+  // Returns per-fork results aligned with the batch; unresolvable refs are null.
+  const [upstreamOwner, upstreamName] = repo.split('/');
+  const batchCompare = async batch => {
+    const fields = batch
+      .map(
+        ({ fork }, i) =>
+          `f${i}: compare(headRef: ${JSON.stringify(`${fork.owner.login}:${fork.default_branch}`)}) { aheadBy behindBy }`
+      )
+      .join(' ');
+    const query =
+      `query { repository(owner: ${JSON.stringify(upstreamOwner)}, name: ${JSON.stringify(upstreamName)}) ` +
+      `{ defaultBranchRef { ${fields} } } }`;
+    const response = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query }),
+      signal,
+    });
+    if (!response.ok) throw Error(response.statusText);
+    const payload = await response.json();
+    const ref = payload.data && payload.data.repository && payload.data.repository.defaultBranchRef;
+    if (!ref) throw Error('GraphQL compare returned no data');
+    return batch.map((_item, i) => ref[`f${i}`] || null);
+  };
+
+  const pump = () => {
+    if (pumping || signal.aborted || !queue.length) return;
+    pumping = true;
+    (async () => {
+      try {
+        while (queue.length && !signal.aborted) {
+          const batch = queue.splice(0, GRAPHQL_BATCH_SIZE);
+          let results;
+          try {
+            results = await batchCompare(batch);
+          } catch (error) {
+            if (error.name === 'AbortError') return;
+            console.error('GraphQL batch compare failed; falling back to REST', error);
+            results = batch.map(() => null);
+          }
+          const failed = [];
+          results.forEach((result, i) => {
+            if (result) {
+              const { fork, rowIdx } = batch[i];
+              fork.compareOwner = fork.owner.login;
+              fork.compareBranch = fork.default_branch;
+              applyResult(rowIdx, result.aheadBy, result.behindBy);
+            } else {
+              failed.push(batch[i]);
+            }
+          });
+          table.draw(false);
+          await Promise.all(failed.map(restCompareItem));
+        }
+      } finally {
+        pumping = false;
+        if (queue.length && !signal.aborted) pump();
+      }
+    })();
   };
 
   const enqueueRow = rowIdx => {
@@ -358,7 +411,7 @@ async function startAheadBehind(repo, baseBranch, forks, headers, signal) {
       .rows({ page: 'current', search: 'applied', order: 'applied' })
       .indexes()
       .each(enqueueRow);
-    spawnWorkers();
+    pump();
   };
 
   // Sorting by Ahead/Behind is only meaningful once every row has data, so a
@@ -370,7 +423,7 @@ async function startAheadBehind(repo, baseBranch, forks, headers, signal) {
       .rows({ search: 'applied', order: 'applied' })
       .indexes()
       .each(enqueueRow);
-    spawnWorkers();
+    pump();
   };
 
   table.off('draw.dt.aheadBehind');

--- a/js/main.js
+++ b/js/main.js
@@ -76,6 +76,7 @@ function updateDT(data) {
   for (let fork of data) {
     if (fork.ahead_by === undefined) fork.ahead_by = null;
     if (fork.behind_by === undefined) fork.behind_by = null;
+    if (fork.latest_release === undefined) fork.latest_release = null;
     fork.repoLink = `<a href="https://github.com/${fork.full_name}">Link</a>`;
     const avatarUrl = (fork.owner && fork.owner.avatar_url) || 'https://avatars.githubusercontent.com/u/0?v=4';
     fork.ownerName = `<img src="${avatarUrl}&s=48" width="24" height="24" loading="lazy" decoding="async" class="me-2 rounded-circle" />${fork.owner ? fork.owner.login : '<strike><em>Unknown</em></strike>'}`;
@@ -135,13 +136,43 @@ function humanizeSize(kilobytes) {
   }).format(value);
 }
 
+function escapeHtml(text) {
+  return String(text).replace(
+    /[&<>"']/g,
+    c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
+  );
+}
+
 function getColumnRenderer(key) {
-  if (key === 'pushed_at') {
+  if (key === 'pushed_at' || key === 'created_at') {
     return (data, type, _row) => {
       if (type === 'display') {
         return howLongAgo(data);
       }
       return data;
+    };
+  }
+  if (key === 'has_issues') {
+    return (data, type, _row) => {
+      if (type === 'display' || type === 'filter') {
+        return data ? 'Yes' : 'No';
+      }
+      return data ? 1 : 0;
+    };
+  }
+  if (key === 'latest_release') {
+    // null means no release found (or not fetched yet — requires a token)
+    return (data, type, _row) => {
+      if (!data) {
+        return type === 'display' || type === 'filter' ? '–' : '';
+      }
+      if (type === 'display') {
+        return `<a href="${escapeHtml(data.url)}">${escapeHtml(data.tagName)}</a>`;
+      }
+      if (type === 'filter') {
+        return data.tagName;
+      }
+      return data.publishedAt || ''; // order chronologically
     };
   }
   if (key === 'size') {
@@ -188,8 +219,11 @@ function initDT() {
     ['Stars', 'stargazers_count'],
     ['Forks', 'forks'],
     ['Open Issues', 'open_issues_count'],
+    ['Issues Enabled', 'has_issues'],
+    ['Release', 'latest_release'], // custom key, filled in by startAheadBehind
     ['Size', 'size'],
     ['Last Push', 'pushed_at'],
+    ['Created', 'created_at'],
   ];
 
   // Sort by stars:
@@ -268,15 +302,20 @@ async function startAheadBehind(repo, baseBranch, forks, headers, signal) {
   const table = window.forkTable;
   const aheadColIdx = window.columnNamesMap.findIndex(colNM => colNM[1] === 'ahead_by');
   const behindColIdx = window.columnNamesMap.findIndex(colNM => colNM[1] === 'behind_by');
+  const releaseColIdx = window.columnNamesMap.findIndex(colNM => colNM[1] === 'latest_release');
   const queue = [];
   const queued = new Set(); // row indexes already fetched or in flight
   let pumping = false;
   let capWarned = false;
 
-  // Does not redraw — callers draw once per batch of updates
+  // These do not redraw — callers draw once per batch of updates
   const applyResult = (rowIdx, ahead, behind) => {
     table.cell(rowIdx, aheadColIdx).data(ahead);
     table.cell(rowIdx, behindColIdx).data(behind);
+  };
+  const applyRelease = (fork, rowIdx, release) => {
+    fork.latest_release = release; // survives redraws sourced from the fork object
+    table.cell(rowIdx, releaseColIdx).data(release);
   };
 
   const compareOnce = async (login, branch) => {
@@ -330,15 +369,23 @@ async function startAheadBehind(repo, baseBranch, forks, headers, signal) {
   // Returns per-fork results aligned with the batch; unresolvable refs are null.
   const [upstreamOwner, upstreamName] = repo.split('/');
   const batchCompare = async batch => {
-    const fields = batch
+    const compareFields = batch
       .map(
         ({ fork }, i) =>
           `f${i}: compare(headRef: ${JSON.stringify(`${fork.owner.login}:${fork.default_branch}`)}) { aheadBy behindBy }`
       )
       .join(' ');
+    // Fetch each fork's latest release in the same request
+    const releaseFields = batch
+      .map(
+        ({ fork }, i) =>
+          `r${i}: repository(owner: ${JSON.stringify(fork.owner.login)}, name: ${JSON.stringify(fork.name)}) ` +
+          '{ latestRelease { tagName url publishedAt } }'
+      )
+      .join(' ');
     const query =
       `query { repository(owner: ${JSON.stringify(upstreamOwner)}, name: ${JSON.stringify(upstreamName)}) ` +
-      `{ defaultBranchRef { ${fields} } } }`;
+      `{ defaultBranchRef { ${compareFields} } } ${releaseFields} }`;
     const response = await fetch('https://api.github.com/graphql', {
       method: 'POST',
       headers,
@@ -347,9 +394,13 @@ async function startAheadBehind(repo, baseBranch, forks, headers, signal) {
     });
     if (!response.ok) throw Error(response.statusText);
     const payload = await response.json();
-    const ref = payload.data && payload.data.repository && payload.data.repository.defaultBranchRef;
+    const data = payload.data;
+    const ref = data && data.repository && data.repository.defaultBranchRef;
     if (!ref) throw Error('GraphQL compare returned no data');
-    return batch.map((_item, i) => ref[`f${i}`] || null);
+    return batch.map((_item, i) => ({
+      compare: ref[`f${i}`] || null,
+      release: (data[`r${i}`] && data[`r${i}`].latestRelease) || null,
+    }));
   };
 
   const pump = () => {
@@ -365,15 +416,18 @@ async function startAheadBehind(repo, baseBranch, forks, headers, signal) {
           } catch (error) {
             if (error.name === 'AbortError') return;
             console.error('GraphQL batch compare failed; falling back to REST', error);
-            results = batch.map(() => null);
+            results = batch.map(() => ({ compare: null, release: null }));
           }
           const failed = [];
           results.forEach((result, i) => {
-            if (result) {
-              const { fork, rowIdx } = batch[i];
+            const { fork, rowIdx } = batch[i];
+            if (result.release) {
+              applyRelease(fork, rowIdx, result.release);
+            }
+            if (result.compare) {
               fork.compareOwner = fork.owner.login;
               fork.compareBranch = fork.default_branch;
-              applyResult(rowIdx, result.aheadBy, result.behindBy);
+              applyResult(rowIdx, result.compare.aheadBy, result.compare.behindBy);
             } else {
               failed.push(batch[i]);
             }
@@ -468,11 +522,31 @@ function fetchAndShow(repo) {
     return response.json();
   });
 
-  Promise.all([upstreamPromise, fetchForkPages(repo, headers, maxPages, controller.signal)])
-    .then(async ([upstream, { forks, truncated }]) => {
+  // The upstream's latest release comes via REST so it also works without a
+  // token; 404 (no releases) is expected
+  const upstreamReleasePromise = fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
+    headers,
+    signal: controller.signal,
+  })
+    .then(response => (response.ok ? response.json() : null))
+    .catch(() => null);
+
+  Promise.all([
+    upstreamPromise,
+    upstreamReleasePromise,
+    fetchForkPages(repo, headers, maxPages, controller.signal),
+  ])
+    .then(async ([upstream, upstreamRelease, { forks, truncated }]) => {
       // Show the upstream repository itself as the first row (it usually also
       // leads the default sort by stars)
       upstream.isUpstream = true;
+      if (upstreamRelease) {
+        upstream.latest_release = {
+          tagName: upstreamRelease.tag_name,
+          url: upstreamRelease.html_url,
+          publishedAt: upstreamRelease.published_at,
+        };
+      }
       forks.unshift(upstream);
       updateDT(forks);
 


### PR DESCRIPTION
## Summary

Third slice of the fork-insight roadmap — three new columns (#25, #63, #43):

- **Created**: fork creation date, rendered as relative time (sorts on the raw timestamp)
- **Issues Enabled**: Yes/No from the fork listing's `has_issues`, filterable via SearchBuilder
- **Release**: the fork's latest release tag, linked to its release page. Fetched via aliased `latestRelease` fields piggybacking on the **same GraphQL batch request** as the ahead/behind compares — zero additional HTTP requests. Sorts chronologically by publish date, filters by tag name; tag names/URLs are HTML-escaped. The upstream row's release comes via REST (`releases/latest`) so it shows even without a token

> **Note:** stacked on #104 — its commits appear in this diff until #104 merges; merge that one first.

## Testing
- `node --check js/main.js`
- The exact combined query produced by the builder (3 real forks: compares + releases in one request) executed successfully via `gh api graphql`; `latestRelease` field shape and null-when-no-release behavior verified live