### PR TITLE
Add CI to publish the extension to Chrome Web Store and AMO

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -7,8 +7,8 @@
 #
 # One-time store setup and the secrets this workflow needs are documented in
 # extension/PUBLISHING.md. Required repository secrets:
-#   CHROME_EXTENSION_ID, CHROME_CLIENT_ID, CHROME_CLIENT_SECRET,
-#   CHROME_REFRESH_TOKEN, AMO_JWT_ISSUER, AMO_JWT_SECRET
+#   CHROME_EXTENSION_ID, CHROME_PUBLISHER_ID, CHROME_CLIENT_ID,
+#   CHROME_CLIENT_SECRET, CHROME_REFRESH_TOKEN, AMO_JWT_ISSUER, AMO_JWT_SECRET
 
 name: Publish extension
 
@@ -34,7 +34,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
 
@@ -58,10 +58,10 @@ jobs:
         if: steps.version.outputs.changed != 'true'
         run: echo "extension/manifest.json version unchanged — nothing to publish. Bump it to release."
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         if: steps.version.outputs.changed == 'true'
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Package extension
         if: steps.version.outputs.changed == 'true'
@@ -74,10 +74,12 @@ jobs:
         if: steps.version.outputs.changed == 'true'
         env:
           EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
           CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
-        run: npx --yes chrome-webstore-upload-cli@3 upload --source active-forks-extension.zip --auto-publish
+        # bare command (no subcommand) uploads and then publishes
+        run: npx --yes chrome-webstore-upload-cli@4 --source active-forks-extension.zip
 
       - name: Publish to Firefox Add-ons
         if: steps.version.outputs.changed == 'true'
@@ -86,11 +88,11 @@ jobs:
           WEB_EXT_API_SECRET: ${{ secrets.AMO_JWT_SECRET }}
         # --approval-timeout 0: exit once the upload is validated instead of
         # polling for AMO's human review to finish
-        run: npx --yes web-ext@8 sign --source-dir extension --channel listed --approval-timeout 0
+        run: npx --yes web-ext@10 sign --source-dir extension --channel listed --approval-timeout 0
 
       - name: Upload packaged zip as artifact
         if: steps.version.outputs.changed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: active-forks-extension-${{ steps.version.outputs.version }}
           path: active-forks-extension.zip

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -67,7 +67,7 @@ jobs:
         if: steps.version.outputs.changed == 'true'
         run: |
           cd extension
-          zip -r -X ../active-forks-extension.zip .
+          zip -r -X ../active-forks-extension.zip . -x PUBLISHING.md
           unzip -l ../active-forks-extension.zip
 
       - name: Publish to Chrome Web Store

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,96 @@
+# Publishes the browser extension to the Chrome Web Store and Firefox Add-ons
+# (AMO) when a merge to main changes extension/ AND bumps the manifest version.
+#
+# Both stores reject re-uploads of an already-published version, so the
+# version guard skips publishing (successfully) when the version is unchanged.
+# To release: bump "version" in extension/manifest.json as part of the PR.
+#
+# One-time store setup and the secrets this workflow needs are documented in
+# extension/PUBLISHING.md. Required repository secrets:
+#   CHROME_EXTENSION_ID, CHROME_CLIENT_ID, CHROME_CLIENT_SECRET,
+#   CHROME_REFRESH_TOKEN, AMO_JWT_ISSUER, AMO_JWT_SECRET
+
+name: Publish extension
+
+on:
+  push:
+    branches: [main]
+    paths: ['extension/**']
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Publish even if the manifest version did not change
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-extension
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check whether the manifest version changed
+        id: version
+        run: |
+          CURR=$(jq -r .version extension/manifest.json)
+          PREV=$(git show 'HEAD^:extension/manifest.json' 2>/dev/null | jq -r .version || echo none)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force }}" = "true" ]; then
+            CHANGED=true
+          elif [ "$CURR" != "$PREV" ]; then
+            CHANGED=true
+          else
+            CHANGED=false
+          fi
+          echo "Version: $PREV -> $CURR (publish: $CHANGED)"
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "version=$CURR" >> "$GITHUB_OUTPUT"
+
+      - name: Skip notice
+        if: steps.version.outputs.changed != 'true'
+        run: echo "extension/manifest.json version unchanged — nothing to publish. Bump it to release."
+
+      - uses: actions/setup-node@v4
+        if: steps.version.outputs.changed == 'true'
+        with:
+          node-version: 22
+
+      - name: Package extension
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          cd extension
+          zip -r -X ../active-forks-extension.zip .
+          unzip -l ../active-forks-extension.zip
+
+      - name: Publish to Chrome Web Store
+        if: steps.version.outputs.changed == 'true'
+        env:
+          EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: npx --yes chrome-webstore-upload-cli@3 upload --source active-forks-extension.zip --auto-publish
+
+      - name: Publish to Firefox Add-ons
+        if: steps.version.outputs.changed == 'true'
+        env:
+          WEB_EXT_API_KEY: ${{ secrets.AMO_JWT_ISSUER }}
+          WEB_EXT_API_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+        # --approval-timeout 0: exit once the upload is validated instead of
+        # polling for AMO's human review to finish
+        run: npx --yes web-ext@8 sign --source-dir extension --channel listed --approval-timeout 0
+
+      - name: Upload packaged zip as artifact
+        if: steps.version.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: active-forks-extension-${{ steps.version.outputs.version }}
+          path: active-forks-extension.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ rather than version.
 
 ### Added
 
+- CI workflow that publishes the browser extension to the Chrome Web Store
+  and Firefox Add-ons on merge to `main` when `extension/` changed and the
+  manifest version was bumped; store setup and required secrets are
+  documented in `extension/PUBLISHING.md`
+  ([#107](https://github.com/techgaun/active-forks/pull/107)).
+
 - A cross-browser (Chrome/Edge/Firefox, Manifest V3) extension in
   `extension/` ([#106](https://github.com/techgaun/active-forks/pull/106)):
   a toolbar popup previewing the current repository's top 10 forks (sortable

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Edge, Firefox — Manifest V3) extension:
 It needs only the `activeTab` and `contextMenus` permissions and talks solely
 to `api.github.com`.
 
-To install from source:
+Store releases are automated — see
+[`extension/PUBLISHING.md`](extension/PUBLISHING.md). To install from source:
 
 - **Chrome/Edge**: open `chrome://extensions`, enable "Developer mode", click
   "Load unpacked", and select the `extension/` directory.

--- a/extension/PUBLISHING.md
+++ b/extension/PUBLISHING.md
@@ -26,7 +26,9 @@ Actions).
 2. Zip the `extension/` directory contents (`cd extension && zip -r ../ext.zip .`)
    and upload it as a new item in the developer console; complete the listing
    (description, screenshots, privacy declarations) and submit for review.
-3. Note the extension ID from the console URL → secret `CHROME_EXTENSION_ID`.
+3. Note the extension ID from the console URL → secret `CHROME_EXTENSION_ID`,
+   and your publisher ID from the developer console account settings →
+   secret `CHROME_PUBLISHER_ID`.
 4. Create OAuth credentials for the Chrome Web Store API — follow the
    [chrome-webstore-upload guide](https://github.com/fregante/chrome-webstore-upload/blob/main/How%20to%20generate%20Google%20API%20keys.md):
    enable the "Chrome Web Store API" on a Google Cloud project, create an

--- a/extension/PUBLISHING.md
+++ b/extension/PUBLISHING.md
@@ -1,0 +1,59 @@
+# Publishing the extension
+
+Merges to `main` that touch `extension/` **and bump `"version"` in
+`manifest.json`** are published automatically to the Chrome Web Store and
+Firefox Add-ons (AMO) by
+[`.github/workflows/publish-extension.yml`](../.github/workflows/publish-extension.yml).
+If the version is unchanged, the workflow skips publishing (both stores
+reject re-uploads of a published version), so a release is: bump the
+version in your PR, merge.
+
+The workflow can also be run manually from the Actions tab
+(`workflow_dispatch`), with a `force` option to attempt publishing without a
+version change.
+
+## One-time setup
+
+Automation can only *update* an existing listing — the **first submission to
+each store must be done manually**, and each store needs API credentials
+stored as GitHub repository secrets (Settings → Secrets and variables →
+Actions).
+
+### Chrome Web Store
+
+1. Register as a [Chrome Web Store developer](https://chrome.google.com/webstore/devconsole)
+   (one-time $5 fee).
+2. Zip the `extension/` directory contents (`cd extension && zip -r ../ext.zip .`)
+   and upload it as a new item in the developer console; complete the listing
+   (description, screenshots, privacy declarations) and submit for review.
+3. Note the extension ID from the console URL → secret `CHROME_EXTENSION_ID`.
+4. Create OAuth credentials for the Chrome Web Store API — follow the
+   [chrome-webstore-upload guide](https://github.com/fregante/chrome-webstore-upload/blob/main/How%20to%20generate%20Google%20API%20keys.md):
+   enable the "Chrome Web Store API" on a Google Cloud project, create an
+   OAuth client, and generate a refresh token. Store as secrets:
+   - `CHROME_CLIENT_ID`
+   - `CHROME_CLIENT_SECRET`
+   - `CHROME_REFRESH_TOKEN`
+
+### Firefox Add-ons (AMO)
+
+1. Sign in at [addons.mozilla.org](https://addons.mozilla.org/developers/)
+   and submit the first version manually ("Submit a New Add-on", listed
+   channel), completing the listing. The add-on ID is already pinned by
+   `browser_specific_settings.gecko.id` in the manifest
+   (`active-forks@techgaun.github.io`) — don't change it.
+2. Generate API credentials at
+   [Manage API Keys](https://addons.mozilla.org/developers/addon/api/key/)
+   and store as secrets:
+   - `AMO_JWT_ISSUER` (the "JWT issuer")
+   - `AMO_JWT_SECRET` (the "JWT secret")
+
+## Notes
+
+- AMO reviews listed versions after upload; the workflow exits once the
+  upload validates rather than waiting for review to finish
+  (`--approval-timeout 0`). Chrome's `--auto-publish` submits for review and
+  publishes when approved.
+- The packaged zip for each published version is attached to the workflow
+  run as an artifact.
+- Keep `"version"` a plain `x.y.z` — both stores are strict about formats.


### PR DESCRIPTION
## Summary

Automates extension store releases (follow-up to #106):

- **Trigger**: push to `main` touching `extension/**` (plus manual `workflow_dispatch` with a `force` input)
- **Version guard**: both stores reject re-uploads of an already-published version, so the workflow compares `manifest.json`'s version against the previous commit and skips publishing (green, with a notice) unless it was bumped. **Releasing = bump the version in your PR and merge**
- **Chrome Web Store**: `chrome-webstore-upload-cli@4` — the bare command uploads and publishes (submits for review; goes live when it passes)
- **Firefox AMO**: `web-ext@10 sign --channel listed --approval-timeout 0` (exits once the upload validates; AMO reviews asynchronously). The add-on identity is pinned by the manifest's `gecko.id`
- The packaged zip is attached to each run as an artifact
- Minimal permissions (`contents: read`), concurrency-guarded so overlapping merges can't double-publish
- Actions on current majors: `checkout@v7`, `setup-node@v7` (Node 24), `upload-artifact@v7`

## Before this can run: one-time manual setup (documented in `extension/PUBLISHING.md`)

The first submission to each store must be manual, and seven repository secrets are needed:
`CHROME_EXTENSION_ID`, `CHROME_PUBLISHER_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`, `AMO_JWT_ISSUER`, `AMO_JWT_SECRET`. Until the secrets exist, a version-bumped merge will fail at the publish steps — set them up before the first bump.

## Testing
- Workflow YAML validated; version-guard shell logic exercised in a scratch repo for both cases (no bump → skip; bump → publish)
- CLI interfaces of the pinned major versions verified from their `--help` output (`chrome-webstore-upload-cli@4` dropped `--auto-publish` and requires `PUBLISHER_ID`; `web-ext@10` sign flags unchanged)